### PR TITLE
♻️ 更新类型注解为Python 3.10+风格

### DIFF
--- a/muicebot/builtin_plugins/get_current_time.py
+++ b/muicebot/builtin_plugins/get_current_time.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from nonebot import get_plugin_config
 from pydantic import BaseModel, Field, field_validator
 
@@ -12,11 +10,11 @@ __plugin_meta__ = PluginMetadata(
 
 
 class Config(BaseModel):
-    timezone: Optional[str] = Field(default=None, description="当前时区", examples=["Asia/Shanghai"])
+    timezone: str | None = Field(default=None, description="当前时区", examples=["Asia/Shanghai"])
 
     @field_validator("timezone", mode="before")
     @classmethod
-    def validate_timezone(cls, value: Optional[str]) -> Optional[str]:
+    def validate_timezone(cls, value: str | None) -> str | None:
         if not value:
             return value
 

--- a/muicebot/builtin_plugins/plugin_store/store.py
+++ b/muicebot/builtin_plugins/plugin_store/store.py
@@ -1,7 +1,6 @@
 import asyncio
 import shutil
 from pathlib import Path
-from typing import Optional
 
 import aiohttp
 from nonebot import logger
@@ -17,7 +16,7 @@ PLUGIN_DIR = Path("plugins/store")
 PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
 
 
-async def get_index() -> Optional[dict[str, PluginInfo]]:
+async def get_index() -> dict[str, PluginInfo] | None:
     """
     获取插件索引
     """

--- a/muicebot/config.py
+++ b/muicebot/config.py
@@ -5,7 +5,7 @@ import os
 import threading
 import time
 from pathlib import Path
-from typing import Callable, List, Literal, Optional
+from typing import Callable, Literal
 
 import yaml as yaml_
 from nonebot import get_plugin_config, logger
@@ -20,7 +20,7 @@ MODELS_CONFIG_PATH = Path("configs/models.yml").resolve()
 SCHEDULES_CONFIG_PATH = Path("configs/schedules.yml").resolve()
 EMBEDDINGS_CONFIG_PATH = Path("configs/embeddings.yml").resolve()
 
-_model_config_manager: Optional["ModelConfigManager"] = None
+_model_config_manager: "ModelConfigManager" | None = None
 _embeddings_configs: dict[str, EmbeddingConfig] = {}
 
 
@@ -39,7 +39,7 @@ class PluginConfig(BaseModel):
     """启用的 Nonebot 适配器"""
     input_timeout: int = 0
     """输入等待时间"""
-    default_template: Optional[str] = "Muice"
+    default_template: str | None = "Muice"
     """默认使用人设模板名称"""
     thought_process_mode: Literal[0, 1, 2] = 2
     """针对 Deepseek-R1 等思考模型的思考过程提取模式"""
@@ -55,9 +55,9 @@ class Schedule(BaseModel):
     """调度器 ID"""
     trigger: Literal["cron", "interval"]
     """调度器类别"""
-    ask: Optional[str] = None
+    ask: str | None = None
     """向大语言模型询问的信息"""
-    say: Optional[str] = None
+    say: str | None = None
     """直接输出的信息"""
     args: dict[str, int]
     """调度器参数"""
@@ -67,7 +67,7 @@ class Schedule(BaseModel):
     """触发几率"""
 
 
-def get_schedule_configs() -> List[Schedule]:
+def get_schedule_configs() -> list[Schedule]:
     """
     从配置文件 `configs/schedules.yml` 中获取所有调度器配置
 
@@ -115,7 +115,7 @@ class ConfigFileHandler(FileSystemEventHandler):
 class ModelConfigManager:
     """模型配置管理器"""
 
-    _instance: Optional["ModelConfigManager"] = None
+    _instance: "ModelConfigManager" | None = None
     _lock = threading.Lock()
     _initialized: bool
     configs: dict[str, ModelConfig]
@@ -136,9 +136,9 @@ class ModelConfigManager:
         """所有模型配置"""
         self.default_config = None
         """默认模型配置（非主 Muice 使用模型）"""
-        self.observer: Optional[BaseObserver] = None
+        self.observer: BaseObserver | None = None
         """文件监视器"""
-        self._listeners: List[Callable] = []
+        self._listeners: list[Callable] = []
         """监听器列表"""
 
         self._load_configs()
@@ -210,7 +210,7 @@ class ModelConfigManager:
         if listener in self._listeners:
             self._listeners.remove(listener)
 
-    def get_model_config(self, model_config_name: Optional[str] = None) -> ModelConfig:
+    def get_model_config(self, model_config_name: str | None = None) -> ModelConfig:
         """获取指定模型的配置"""
         if model_config_name in [None, ""]:
             if not self.default_config:
@@ -256,7 +256,7 @@ def get_model_config_manager() -> ModelConfigManager:
     return _model_config_manager
 
 
-def get_model_config(model_config_name: Optional[str] = None) -> ModelConfig:
+def get_model_config(model_config_name: str | None = None) -> ModelConfig:
     """
     从配置文件 `configs/models.yml` 中获取指定模型的配置对象
 
@@ -268,7 +268,7 @@ def get_model_config(model_config_name: Optional[str] = None) -> ModelConfig:
     return model_config_manager.get_model_config(model_config_name)
 
 
-def get_embedding_model_config(embedding_config_name: Optional[str] = None) -> EmbeddingConfig:
+def get_embedding_model_config(embedding_config_name: str | None = None) -> EmbeddingConfig:
     """
     从配置文件 `configs/models.yml` 中获取指定模型的配置对象
 

--- a/muicebot/database/crud.py
+++ b/muicebot/database/crud.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import List, Literal, Optional
+from typing import Literal
 
 from nonebot_plugin_orm import async_scoped_session
 from sqlalchemy import desc, func, select, update
@@ -62,7 +62,7 @@ class MessageORM:
         )
 
     @staticmethod
-    async def get_user_history(session: async_scoped_session, userid: str, limit: int = 0) -> List[Message]:
+    async def get_user_history(session: async_scoped_session, userid: str, limit: int = 0) -> list[Message]:
         """
         获取用户的所有对话历史
 
@@ -80,7 +80,7 @@ class MessageORM:
         return [MessageORM._convert(msg) for msg in rows][::-1]
 
     @staticmethod
-    async def get_group_history(session: async_scoped_session, groupid: str, limit: int = 0) -> List[Message]:
+    async def get_group_history(session: async_scoped_session, groupid: str, limit: int = 0) -> list[Message]:
         """
         获取群组的所有对话历史，返回一个列表
 
@@ -100,7 +100,7 @@ class MessageORM:
     async def mark_history_as_unavailable(
         session: async_scoped_session,
         userid: str,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ):
         """
         将用户消息上下文标记为不可用 (适用于 reset 命令)
@@ -197,9 +197,9 @@ class UsageORM:
     @staticmethod
     async def get_usage(
         session: async_scoped_session,
-        plugin: Optional[str],
-        date: Optional[str],
-        type: Optional[Literal["chat", "embedding"]] = None,
+        plugin: str | None,
+        date: str | None,
+        type: Literal["chat", "embedding"] | None = None,
     ) -> int:
         """
         获取用量信息

--- a/muicebot/llm/_base.py
+++ b/muicebot/llm/_base.py
@@ -5,7 +5,7 @@ import json
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, AsyncGenerator, Literal, Optional, Union, overload
+from typing import Any, AsyncGenerator, Literal, overload
 
 import numpy as np
 from nonebot import logger
@@ -106,7 +106,7 @@ class BaseLLM(ABC):
     @abstractmethod
     async def ask(
         self, request: "ModelRequest", *, stream: bool = False
-    ) -> Union["ModelCompletions", AsyncGenerator["ModelStreamCompletions", None]]:
+    ) -> "ModelCompletions" | AsyncGenerator["ModelStreamCompletions", None]:
         """
         模型交互询问
 
@@ -159,7 +159,7 @@ class EmbeddingModel(ABC):
         if missing_fields:
             raise ValueError(f"对于 {self.config.provider} 嵌入模型，以下配置是必需的: {', '.join(missing_fields)}")
 
-    def _get_embedding_cache_path(self, text: str) -> Optional[Path]:
+    def _get_embedding_cache_path(self, text: str) -> Path | None:
         """
         获取嵌入缓存文件路径
 
@@ -175,7 +175,7 @@ class EmbeddingModel(ABC):
         return self.cache_dir / cache_key
 
     @lru_cache(maxsize=256)
-    def _load_embedding_from_cache(self, text: str) -> Optional[ndarray]:
+    def _load_embedding_from_cache(self, text: str) -> ndarray | None:
         """
         从缓存文件中加载嵌入向量
 

--- a/muicebot/llm/_config.py
+++ b/muicebot/llm/_config.py
@@ -1,5 +1,5 @@
 from importlib.util import find_spec
-from typing import Any, List, Literal, Optional
+from typing import Any, Literal
 from warnings import warn
 
 from pydantic import BaseModel, field_validator, model_validator
@@ -8,12 +8,12 @@ from pydantic import BaseModel, field_validator, model_validator
 class ModelConfig(BaseModel):
     provider: str
     """所使用模型提供者的名称，位于 llm/providers 下"""
-    loader: Optional[str] = None
+    loader: str | None = None
     """[弃用] 所使用加载器的名称，位于 llm 文件夹下，loader 开头必须大写"""
     default: bool = False
     """是否默认启用"""
 
-    template: Optional[str] = "Muice"
+    template: str | None = "Muice"
     """使用的人设模板名称"""
     template_mode: Literal["system", "user"] = "system"
     """模板嵌入模式: `system` 为嵌入到系统提示; `user` 为嵌入到用户提示中"""
@@ -26,11 +26,11 @@ class ModelConfig(BaseModel):
     """模型的 top_p 系数"""
     top_k: float = 3
     """模型的 top_k 系数"""
-    frequency_penalty: Optional[float] = None
+    frequency_penalty: float | None = None
     """模型的频率惩罚"""
-    presence_penalty: Optional[float] = None
+    presence_penalty: float | None = None
     """模型的存在惩罚"""
-    repetition_penalty: Optional[float] = None
+    repetition_penalty: float | None = None
     """模型的重复惩罚"""
     stream: bool = False
     """是否使用流式输出"""
@@ -55,18 +55,18 @@ class ModelConfig(BaseModel):
     api_host: str = ""
     """自定义 API 地址"""
 
-    extra_body: Optional[dict] = None
+    extra_body: dict | None = None
     """OpenAI 的 extra_body"""
-    enable_thinking: Optional[bool] = None
+    enable_thinking: bool | None = None
     """Dashscope 的 enable_thinking"""
-    thinking_budget: Optional[int] = None
+    thinking_budget: int | None = None
     """Dashscope 的 thinking_budget"""
 
     multimodal: bool = False
     """是否为（或启用）多模态模型"""
-    modalities: List[Literal["text", "audio", "image"]] = ["text"]
+    modalities: list[Literal["text", "audio", "image"]] = ["text"]
     """生成模态"""
-    audio: Optional[Any] = None
+    audio: Any | None = None
     """多模态音频参数"""
 
     @field_validator("provider")

--- a/muicebot/llm/_schema.py
+++ b/muicebot/llm/_schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, List, Literal, Optional, Type
+from typing import TYPE_CHECKING, Literal, Type
 
 from pydantic import BaseModel
 
@@ -18,12 +18,12 @@ class ModelRequest:
     """
 
     prompt: str
-    history: List[Message] = field(default_factory=list)
-    resources: List[Resource] = field(default_factory=list)
-    tools: Optional[List[dict]] = field(default_factory=list)
-    system: Optional[str] = None
+    history: list[Message] = field(default_factory=list)
+    resources: list[Resource] = field(default_factory=list)
+    tools: list[dict] | None = field(default_factory=list)
+    system: str | None = None
     format: Literal["string", "json"] = "string"
-    json_schema: Optional[Type[BaseModel]] = None
+    json_schema: Type[BaseModel] | None = None
 
 
 @dataclass
@@ -36,7 +36,7 @@ class ModelCompletions:
     """输出文本内容"""
     usage: int = -1
     """总调用用量"""
-    resources: List[Resource] = field(default_factory=list)
+    resources: list[Resource] = field(default_factory=list)
     """模型输出多模态资源列表"""
     succeed: bool = True
     """调用成功（如不成功会在 `text` 中输出错误信息）"""
@@ -52,7 +52,7 @@ class ModelStreamCompletions:
     """输出文本块"""
     usage: int = -1
     """总调用用量（累增，一般取最后一个块的用量）"""
-    resources: Optional[List[Resource]] = field(default_factory=list)
+    resources: list[Resource] | None = field(default_factory=list)
     """模型输出多模态资源列表"""
     succeed: bool = True
     """调用成功（如不成功会在 `chunk` 中输出错误信息）"""
@@ -64,12 +64,12 @@ class EmbeddingsBatchResult:
     嵌入输出
     """
 
-    embeddings: List[List[float]]
+    embeddings: list[list[float]]
     usage: int = -1
     succeed: bool = True
 
     @property
-    def array(self) -> List["ndarray"]:
+    def array(self) -> list["ndarray"]:
         from numpy import array
 
         return [array(embedding) for embedding in self.embeddings]

--- a/muicebot/llm/_wrapper.py
+++ b/muicebot/llm/_wrapper.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from functools import wraps
-from typing import TYPE_CHECKING, AsyncGenerator, Awaitable, Callable, TypeAlias, Union
+from typing import TYPE_CHECKING, AsyncGenerator, Awaitable, Callable, TypeAlias
 
 from nonebot_plugin_orm import get_scoped_session
 
@@ -18,7 +18,7 @@ from ._schema import (
 if TYPE_CHECKING:
     from ._base import BaseLLM, EmbeddingModel
 
-ASK_FUNC: TypeAlias = Callable[..., Awaitable[Union[ModelCompletions, AsyncGenerator[ModelStreamCompletions, None]]]]
+ASK_FUNC: TypeAlias = Callable[..., Awaitable[ModelCompletions | AsyncGenerator[ModelStreamCompletions, None]]]
 EMBED_FUNC: TypeAlias = Callable[..., Awaitable[EmbeddingsBatchResult]]
 
 _usage_write_lock = asyncio.Lock()

--- a/muicebot/llm/providers/_echo.py
+++ b/muicebot/llm/providers/_echo.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncGenerator, List, Literal, Union, overload
+from typing import Any, AsyncGenerator, Literal, overload
 
 from .. import (
     BaseLLM,
@@ -26,7 +26,7 @@ class Echo(BaseLLM):
 
         此模型加载器支持的多模态类型: `audio` `image` `video` `file`
         """
-        user_content: List[dict] = [{"type": "text", "text": request.prompt}]
+        user_content: list[dict] = [{"type": "text", "text": request.prompt}]
 
         for resource in request.resources:
             if resource.path is None:
@@ -122,7 +122,7 @@ class Echo(BaseLLM):
 
     async def ask(
         self, request: ModelRequest, *, stream: bool = False
-    ) -> Union[ModelCompletions, AsyncGenerator[ModelStreamCompletions, None]]:
+    ) -> ModelCompletions | AsyncGenerator[ModelStreamCompletions, None]:
         """
         模型交互询问
 

--- a/muicebot/llm/providers/azure.py
+++ b/muicebot/llm/providers/azure.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import AsyncGenerator, List, Literal, Optional, Union, overload
+from typing import AsyncGenerator, Literal, overload
 
 from azure.ai.inference.aio import ChatCompletionsClient
 from azure.ai.inference.models import (
@@ -58,7 +58,7 @@ class Azure(BaseLLM):
 
         此模型加载器支持的多模态类型: `audio` `image`
         """
-        multi_content_items: List[ContentItem] = []
+        multi_content_items: list[ContentItem] = []
 
         for resource in request.resources:
             if resource.path is None:
@@ -84,7 +84,7 @@ class Azure(BaseLLM):
 
         return UserMessage(content=content)
 
-    def __build_tools_definition(self, tools: List[dict]) -> List[ChatCompletionsToolDefinition]:
+    def __build_tools_definition(self, tools: list[dict]) -> list[ChatCompletionsToolDefinition]:
         tool_definitions = []
 
         for tool in tools:
@@ -99,8 +99,8 @@ class Azure(BaseLLM):
 
         return tool_definitions
 
-    def _build_messages(self, request: ModelRequest) -> List[ChatRequestMessage]:
-        messages: List[ChatRequestMessage] = []
+    def _build_messages(self, request: ModelRequest) -> list[ChatRequestMessage]:
+        messages: list[ChatRequestMessage] = []
 
         if request.system:
             messages.append(SystemMessage(request.system))
@@ -120,7 +120,7 @@ class Azure(BaseLLM):
 
         return messages
 
-    def _tool_messages_precheck(self, tool_calls: Optional[List[ChatCompletionsToolCall]] = None) -> bool:
+    def _tool_messages_precheck(self, tool_calls: list[ChatCompletionsToolCall] | None = None) -> bool:
         if not (tool_calls and len(tool_calls) == 1):
             return False
 
@@ -133,9 +133,9 @@ class Azure(BaseLLM):
 
     async def _ask_sync(
         self,
-        messages: List[ChatRequestMessage],
-        tools: List[ChatCompletionsToolDefinition],
-        response_format: Optional[JsonSchemaFormat],
+        messages: list[ChatRequestMessage],
+        tools: list[ChatCompletionsToolDefinition],
+        response_format: JsonSchemaFormat | None,
         total_tokens: int = 0,
     ) -> ModelCompletions:
         client = ChatCompletionsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.token))
@@ -207,9 +207,9 @@ class Azure(BaseLLM):
 
     async def _ask_stream(
         self,
-        messages: List[ChatRequestMessage],
-        tools: List[ChatCompletionsToolDefinition],
-        response_format: Optional[JsonSchemaFormat],
+        messages: list[ChatRequestMessage],
+        tools: list[ChatCompletionsToolDefinition],
+        response_format: JsonSchemaFormat | None,
         total_tokens: int = 0,
     ) -> AsyncGenerator[ModelStreamCompletions, None]:
         client = ChatCompletionsClient(endpoint=self.endpoint, credential=AzureKeyCredential(self.token))
@@ -314,7 +314,7 @@ class Azure(BaseLLM):
 
     async def ask(
         self, request: ModelRequest, *, stream: bool = False
-    ) -> Union[ModelCompletions, AsyncGenerator[ModelStreamCompletions, None]]:
+    ) -> ModelCompletions | AsyncGenerator[ModelStreamCompletions, None]:
         messages = self._build_messages(request)
 
         tools = self.__build_tools_definition(request.tools) if request.tools else []

--- a/muicebot/llm/providers/dashscope.py
+++ b/muicebot/llm/providers/dashscope.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from dataclasses import dataclass
 from functools import partial
-from typing import AsyncGenerator, Generator, List, Literal, Optional, Union, overload
+from typing import AsyncGenerator, Generator, Literal, overload
 
 import dashscope
 from dashscope.api_entities.dashscope_response import (
@@ -105,7 +105,7 @@ class Dashscope(BaseLLM):
 
         此模型加载器支持的多模态类型: `audio` `image`
         """
-        multi_contents: List[dict[str, str]] = []
+        multi_contents: list[dict[str, str]] = []
 
         for item in request.resources:
             if item.type == "audio":
@@ -122,7 +122,7 @@ class Dashscope(BaseLLM):
 
         return {"role": "user", "content": user_content}
 
-    def _build_messages(self, request: ModelRequest) -> List[dict]:
+    def _build_messages(self, request: ModelRequest) -> list[dict]:
         messages = []
 
         if request.system:
@@ -150,8 +150,8 @@ class Dashscope(BaseLLM):
     async def _GenerationResponse_handle(
         self,
         messages: list,
-        tools: List[dict],
-        response_format: Optional[dict],
+        tools: list[dict],
+        response_format: dict | None,
         response: GenerationResponse | MultiModalConversationResponse,
         total_tokens: int,
     ) -> ModelCompletions:
@@ -190,8 +190,8 @@ class Dashscope(BaseLLM):
     async def _Generator_handle(
         self,
         messages: list,
-        tools: List[dict],
-        response_format: Optional[dict],
+        tools: list[dict],
+        response_format: dict | None,
         response: Generator[GenerationResponse, None, None] | Generator[MultiModalConversationResponse, None, None],
         total_tokens: int = 0,
     ) -> AsyncGenerator[ModelStreamCompletions, None]:
@@ -250,9 +250,9 @@ class Dashscope(BaseLLM):
 
     async def _tool_calls_handle_sync(
         self,
-        messages: List,
-        tools: List[dict],
-        response_format: Optional[dict],
+        messages: list,
+        tools: list[dict],
+        response_format: dict | None,
         response: GenerationResponse | MultiModalConversationResponse,
         total_tokens: int,
     ) -> ModelCompletions:
@@ -279,9 +279,9 @@ class Dashscope(BaseLLM):
 
     async def _tool_calls_handle_stream(
         self,
-        messages: List,
-        tools: List[dict],
-        response_format: Optional[dict],
+        messages: list,
+        tools: list[dict],
+        response_format: dict | None,
         func_stream: FunctionCallStream,
         total_tokens: int,
     ) -> AsyncGenerator[ModelStreamCompletions, None]:
@@ -322,10 +322,10 @@ class Dashscope(BaseLLM):
     async def _ask(
         self,
         messages: list,
-        tools: List[dict],
-        response_format: Optional[dict],
+        tools: list[dict],
+        response_format: dict | None,
         total_tokens: int = 0,
-    ) -> Union[ModelCompletions, AsyncGenerator[ModelStreamCompletions, None]]:
+    ) -> ModelCompletions | AsyncGenerator[ModelStreamCompletions, None]:
         loop = asyncio.get_event_loop()
 
         # 因为 Dashscope 对于多模态模型的接口不同，所以这里不能统一函数
@@ -387,7 +387,7 @@ class Dashscope(BaseLLM):
 
     async def ask(
         self, request: ModelRequest, *, stream: bool = False
-    ) -> Union[ModelCompletions, AsyncGenerator[ModelStreamCompletions, None]]:
+    ) -> ModelCompletions | AsyncGenerator[ModelStreamCompletions, None]:
         self.stream = stream if stream is not None else False
 
         tools = request.tools if request.tools else []

--- a/muicebot/llm/providers/gemini.py
+++ b/muicebot/llm/providers/gemini.py
@@ -1,11 +1,8 @@
 from typing import (
     AsyncGenerator,
     Awaitable,
-    List,
     Literal,
-    Optional,
     Type,
-    Union,
     overload,
 )
 
@@ -85,7 +82,7 @@ class Gemini(BaseLLM):
         )
 
     def _build_gemini_config(
-        self, tools: Optional[List[dict]], response_format: Optional[Type[BaseModel]]
+        self, tools: list[dict] | None, response_format: Type[BaseModel] | None
     ) -> GenerateContentConfig:
         gemini_config = self.gemini_config.model_copy()
         format_tools = []
@@ -130,7 +127,7 @@ class Gemini(BaseLLM):
         return user_parts
 
     def _build_messages(self, request: ModelRequest) -> list[ContentOrDict]:
-        messages: List[ContentOrDict] = []
+        messages: list[ContentOrDict] = []
 
         if request.history:
             for index, item in enumerate(request.history):
@@ -148,8 +145,8 @@ class Gemini(BaseLLM):
     async def _ask_sync(
         self,
         messages: list[ContentOrDict],
-        tools: Optional[List[dict]],
-        response_format: Optional[Type[BaseModel]],
+        tools: list[dict] | None,
+        response_format: Type[BaseModel] | None,
         total_tokens: int = 0,
     ) -> ModelCompletions:
         gemini_config = self._build_gemini_config(tools, response_format)
@@ -216,8 +213,8 @@ class Gemini(BaseLLM):
     async def _ask_stream(
         self,
         messages: list,
-        tools: Optional[List[dict]],
-        response_format: Optional[Type[BaseModel]],
+        tools: list[dict] | None,
+        response_format: Type[BaseModel] | None,
         total_tokens: int = 0,
     ) -> AsyncGenerator[ModelStreamCompletions, None]:
         gemini_config = self._build_gemini_config(tools, response_format)
@@ -305,7 +302,7 @@ class Gemini(BaseLLM):
 
     async def ask(
         self, request: ModelRequest, *, stream: bool = False
-    ) -> Union[ModelCompletions, AsyncGenerator[ModelStreamCompletions, None]]:
+    ) -> ModelCompletions | AsyncGenerator[ModelStreamCompletions, None]:
         messages = self._build_messages(request)
         response_format = request.json_schema if request.format == "json" else None
 

--- a/muicebot/llm/providers/ollama.py
+++ b/muicebot/llm/providers/ollama.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncGenerator, List, Literal, Optional, Union, overload
+from typing import Any, AsyncGenerator, Literal, overload
 
 import ollama
 from nonebot import logger
@@ -83,8 +83,8 @@ class Ollama(BaseLLM):
     async def _ask_sync(
         self,
         messages: list,
-        tools: List[dict[str, Any]],
-        response_format: Optional[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        response_format: dict[str, Any] | None,
         total_tokens: int = -1,
     ) -> ModelCompletions:
         completions = ModelCompletions()
@@ -136,8 +136,8 @@ class Ollama(BaseLLM):
     async def _ask_stream(
         self,
         messages: list,
-        tools: List[dict[str, Any]],
-        response_format: Optional[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        response_format: dict[str, Any] | None,
         total_tokens: int = -1,
     ) -> AsyncGenerator[ModelStreamCompletions, None]:
         try:
@@ -201,7 +201,7 @@ class Ollama(BaseLLM):
 
     async def ask(
         self, request: ModelRequest, *, stream: bool = False
-    ) -> Union[ModelCompletions, AsyncGenerator[ModelStreamCompletions, None]]:
+    ) -> ModelCompletions | AsyncGenerator[ModelStreamCompletions, None]:
         tools = request.tools if request.tools else []
         messages = self._build_messages(request)
         if request.format == "json" and request.json_schema:

--- a/muicebot/llm/providers/openai.py
+++ b/muicebot/llm/providers/openai.py
@@ -1,7 +1,7 @@
 import base64
 import json
 from io import BytesIO
-from typing import AsyncGenerator, List, Literal, Union, overload
+from typing import AsyncGenerator, Literal, overload
 
 import openai
 from nonebot import logger
@@ -28,8 +28,8 @@ from ..utils.tools import function_call_handler
 
 @register("openai")
 class Openai(BaseLLM):
-    _tools: List[ChatCompletionToolParam]
-    modalities: Union[List[Literal["text", "audio"]], NotGiven]
+    _tools: list[ChatCompletionToolParam]
+    modalities: list[Literal["text", "audio"]] | NotGiven
 
     def __init__(self, model_config: ModelConfig) -> None:
         super().__init__(model_config)
@@ -52,7 +52,7 @@ class Openai(BaseLLM):
 
         此模型加载器支持的多模态类型: `audio` `image` `video` `file`
         """
-        user_content: List[dict] = [{"type": "text", "text": request.prompt}]
+        user_content: list[dict] = [{"type": "text", "text": request.prompt}]
 
         for resource in request.resources:
             if resource.path is None:
@@ -125,8 +125,8 @@ class Openai(BaseLLM):
     async def _ask_sync(
         self,
         messages: list,
-        tools: Union[List[ChatCompletionToolParam], NotGiven],
-        response_format: Union[ResponseFormatJSONSchema, NotGiven],
+        tools: list[ChatCompletionToolParam] | NotGiven,
+        response_format: ResponseFormatJSONSchema | NotGiven,
         total_tokens: int = 0,
     ) -> ModelCompletions:
         completions = ModelCompletions()
@@ -205,8 +205,8 @@ class Openai(BaseLLM):
     async def _ask_stream(
         self,
         messages: list,
-        tools: Union[List[ChatCompletionToolParam], NotGiven],
-        response_format: Union[ResponseFormatJSONSchema, NotGiven],
+        tools: list[ChatCompletionToolParam] | NotGiven,
+        response_format: ResponseFormatJSONSchema | NotGiven,
         total_tokens: int = 0,
     ) -> AsyncGenerator[ModelStreamCompletions, None]:
         is_insert_think_label = False
@@ -354,7 +354,7 @@ class Openai(BaseLLM):
 
     async def ask(
         self, request: ModelRequest, *, stream: bool = False
-    ) -> Union[ModelCompletions, AsyncGenerator[ModelStreamCompletions, None]]:
+    ) -> ModelCompletions | AsyncGenerator[ModelStreamCompletions, None]:
         tools = request.tools if request.tools else NOT_GIVEN
 
         messages = self._build_messages(request)

--- a/muicebot/llm/registry.py
+++ b/muicebot/llm/registry.py
@@ -1,9 +1,9 @@
-from typing import Dict, Type
+from typing import Type
 
 from ._base import BaseLLM, EmbeddingModel
 
-LLM_REGISTRY: Dict[str, Type[BaseLLM]] = {}
-EMBEDDING_REGISTRY: Dict[str, Type[EmbeddingModel]] = {}
+LLM_REGISTRY: dict[str, Type[BaseLLM]] = {}
+EMBEDDING_REGISTRY: dict[str, Type[EmbeddingModel]] = {}
 
 
 def register(name: str):

--- a/muicebot/llm/utils/images.py
+++ b/muicebot/llm/utils/images.py
@@ -1,8 +1,7 @@
 import base64
-from typing import Optional
 
 
-def get_file_base64(local_path: Optional[str] = None, file_bytes: Optional[bytes] = None) -> str:
+def get_file_base64(local_path: str | None = None, file_bytes: bytes | None = None) -> str:
     """
     获取本地图像 Base64 的方法
     """

--- a/muicebot/models.py
+++ b/muicebot/models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from functools import total_ordering
 from io import BytesIO
 from mimetypes import guess_extension
-from typing import List, Literal, Optional, Union
+from typing import Literal
 
 
 @dataclass
@@ -14,13 +14,13 @@ class Resource:
     """消息类型"""
     path: str = field(default_factory=str)
     """本地存储地址(对于模型处理是必需的)"""
-    url: Optional[str] = field(default=None)
+    url: str | None = field(default=None)
     """远程存储地址(一般不传入模型处理中)"""
-    raw: Optional[Union[bytes, BytesIO]] = field(default=None)
+    raw: bytes | BytesIO | None = field(default=None)
     """二进制数据（只使用于模型返回且不保存到数据库中）"""
-    mimetype: Optional[str] = field(default=None)
+    mimetype: str | None = field(default=None)
     """文件元数据类型(eg. `image/jpeg`)"""
-    extension: Optional[str] = field(default=None)
+    extension: str | None = field(default=None)
     """文件扩展名(eg. `.jpg`)"""
 
     def __post_init__(self):
@@ -29,7 +29,7 @@ class Resource:
     def __hash__(self) -> int:
         return hash(self.get_file())
 
-    def get_file(self) -> Union[str, bytes, BytesIO]:
+    def get_file(self) -> str | bytes | BytesIO:
         """
         从所有可能的值中获得一个文件对象
 
@@ -80,7 +80,7 @@ class Message:
     """模型回复（不包含思维过程）"""
     history: int = 1
     """消息是否可用于对话历史中，以整数形式映射布尔值"""
-    resources: List[Resource] = field(default_factory=list)
+    resources: list[Resource] = field(default_factory=list)
     """多模态消息内容"""
     usage: int = -1
     """使用的总 tokens, 若模型加载器不支持则设为-1"""

--- a/muicebot/muice.py
+++ b/muicebot/muice.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import AsyncGenerator, Optional, Union
+from typing import AsyncGenerator
 
 from nonebot import logger
 from nonebot_plugin_orm import async_scoped_session
@@ -114,7 +114,7 @@ class Muice:
 
         return True
 
-    def _on_config_changed(self, new_config: ModelConfig, old_config: Optional[ModelConfig] = None):
+    def _on_config_changed(self, new_config: ModelConfig, old_config: ModelConfig | None = None):
         """配置文件变更时的回调函数"""
         logger.info("检测到配置文件变更，自动重载模型...")
         # 更新配置
@@ -128,7 +128,7 @@ class Muice:
         self.load_model()
         logger.success(f"模型自动重载完成: {old_config_name} -> {self.model_config_name}")
 
-    def change_model_config(self, config_name: Optional[str] = None, reload: bool = False) -> str:
+    def change_model_config(self, config_name: str | None = None, reload: bool = False) -> str:
         """
         更换模型配置文件并重新加载模型
 
@@ -338,7 +338,7 @@ class Muice:
 
         total_reply = ""
         total_resources: list[Resource] = []
-        item: Optional[ModelStreamCompletions] = None
+        item: ModelStreamCompletions | None = None
 
         async for item in response:
             await hook_manager.run(HookType.ON_STREAM_CHUNK, item)
@@ -386,7 +386,7 @@ class Muice:
 
     async def refresh(
         self, userid: str, session: async_scoped_session
-    ) -> Union[AsyncGenerator[ModelStreamCompletions, None], ModelCompletions]:
+    ) -> AsyncGenerator[ModelStreamCompletions, None] | ModelCompletions:
         """
         刷新对话
 

--- a/muicebot/plugin/context.py
+++ b/muicebot/plugin/context.py
@@ -3,7 +3,6 @@
 """
 
 from contextvars import ContextVar
-from typing import Tuple
 
 from nonebot.adapters import Bot, Event
 from nonebot.matcher import Matcher
@@ -43,7 +42,7 @@ def set_ctx(bot: Bot, event: Event, state: T_State, matcher: Matcher):
     mather_context.set(matcher)
 
 
-def get_ctx() -> Tuple[Bot, Event, T_State, Matcher]:
+def get_ctx() -> tuple[Bot, Event, T_State, Matcher]:
     """
     获取当前上下文
     """

--- a/muicebot/plugin/func_call/_types.py
+++ b/muicebot/plugin/func_call/_types.py
@@ -1,7 +1,7 @@
-from typing import Any, Callable, Coroutine, TypeVar, Union
+from typing import Any, Callable, Coroutine, TypeVar
 
 SYNC_FUNCTION_CALL_FUNC = Callable[..., str]
 ASYNC_FUNCTION_CALL_FUNC = Callable[..., Coroutine[str, Any, str]]
-FUNCTION_CALL_FUNC = Union[SYNC_FUNCTION_CALL_FUNC, ASYNC_FUNCTION_CALL_FUNC]
+FUNCTION_CALL_FUNC = SYNC_FUNCTION_CALL_FUNC | ASYNC_FUNCTION_CALL_FUNC
 
 F = TypeVar("F", bound=FUNCTION_CALL_FUNC)

--- a/muicebot/plugin/func_call/caller.py
+++ b/muicebot/plugin/func_call/caller.py
@@ -9,7 +9,7 @@
 """
 
 import inspect
-from typing import Any, Optional, Type, get_type_hints
+from typing import Any, Type, get_type_hints
 
 from nonebot import logger
 from nonebot.adapters import Bot, Event
@@ -30,16 +30,16 @@ _caller_data: dict[str, "Caller"] = {}
 
 
 class Caller:
-    def __init__(self, description: str, params: Optional[Type[BaseModel]] = None, rule: Optional[Rule] = None):
+    def __init__(self, description: str, params: Type[BaseModel] | None = None, rule: Rule | None = None):
         self._name: str = ""
         """函数名称"""
         self._description: str = description
         """函数描述"""
-        self._rule: Optional[Rule] = rule
+        self._rule: Rule | None = rule
         """启用规则"""
         self._parameters: dict[str, Parameter] = {}
         """函数参数字典"""
-        self._parameters_model: Optional[Type[BaseModel]] = params
+        self._parameters_model: Type[BaseModel] | None = params
         """函数参数 pydantic 模型"""
         self.function: ASYNC_FUNCTION_CALL_FUNC
         """函数对象"""
@@ -172,7 +172,7 @@ class Caller:
         }
 
 
-def on_function_call(description: str, params: Optional[Type[BaseModel]] = None, rule: Optional[Rule] = None) -> Caller:
+def on_function_call(description: str, params: Type[BaseModel] | None = None, rule: Rule | None = None) -> Caller:
     """
     返回一个Caller类，可用于装饰一个函数，使其注册为一个可被AI调用的function call函数
 

--- a/muicebot/plugin/hook/_types.py
+++ b/muicebot/plugin/hook/_types.py
@@ -1,14 +1,14 @@
 from enum import Enum, auto
-from typing import Awaitable, Callable, Union
+from typing import Awaitable, Callable
 
 from muicebot.llm import ModelCompletions, ModelRequest, ModelStreamCompletions
 from muicebot.models import Message
 
 SYNC_HOOK_FUNC = Callable[..., None]
 ASYNC_HOOK_FUNC = Callable[..., Awaitable[None]]
-HOOK_FUNC = Union[SYNC_HOOK_FUNC, ASYNC_HOOK_FUNC]
+HOOK_FUNC = SYNC_HOOK_FUNC | ASYNC_HOOK_FUNC
 
-HOOK_ARGS = Union[Message, ModelCompletions, ModelStreamCompletions, ModelRequest]
+HOOK_ARGS = Message | ModelCompletions | ModelStreamCompletions | ModelRequest
 
 
 class HookType(Enum):

--- a/muicebot/plugin/hook/manager.py
+++ b/muicebot/plugin/hook/manager.py
@@ -4,9 +4,6 @@ from typing import (
     Any,
     Awaitable,
     Callable,
-    Dict,
-    List,
-    Optional,
     Union,
     get_args,
     get_origin,
@@ -38,7 +35,7 @@ def _match_union(param_type: type, arg: object) -> bool:
 
 class HookManager:
     def __init__(self):
-        self._hooks: Dict[HookType, List["Hooked"]] = defaultdict(list)
+        self._hooks: dict[HookType, list["Hooked"]] = defaultdict(list)
 
     async def _inject_dependencies(self, function: HOOK_FUNC, *hook_args: HOOK_ARGS) -> dict:
         """
@@ -114,16 +111,14 @@ hook_manager = HookManager()
 class Hooked:
     """挂钩函数对象"""
 
-    def __init__(
-        self, hook_type: HookType, priority: int = 10, stream: Optional[bool] = None, rule: Optional[Rule] = None
-    ):
+    def __init__(self, hook_type: HookType, priority: int = 10, stream: bool | None = None, rule: Rule | None = None):
         self.hook_type = hook_type
         """钩子函数类型"""
         self.priority = priority
         """函数调用优先级"""
         self.stream = stream
         """是否仅在(非)流式中运行"""
-        self.rule: Optional[Rule] = rule
+        self.rule: Rule | None = rule
         """启用规则"""
 
         self.function: HOOK_FUNC
@@ -146,7 +141,7 @@ class Hooked:
         return func
 
 
-def on_before_pretreatment(priority: int = 10, rule: Optional[Rule] = None) -> Hooked:
+def on_before_pretreatment(priority: int = 10, rule: Rule | None = None) -> Hooked:
     """
     注册一个钩子函数
     这个函数将在传入消息 (`Muice` 的 `_prepare_prompt()`) 前调用
@@ -158,7 +153,7 @@ def on_before_pretreatment(priority: int = 10, rule: Optional[Rule] = None) -> H
     return Hooked(HookType.BEFORE_PRETREATMENT, priority=priority, rule=rule)
 
 
-def on_before_completion(priority: int = 10, rule: Optional[Rule] = None) -> Hooked:
+def on_before_completion(priority: int = 10, rule: Rule | None = None) -> Hooked:
     """
     注册一个钩子函数。
     这个函数将在传入模型(`Muice` 的 `model.ask()`)前调用
@@ -170,7 +165,7 @@ def on_before_completion(priority: int = 10, rule: Optional[Rule] = None) -> Hoo
     return Hooked(HookType.BEFORE_MODEL_COMPLETION, priority=priority, rule=rule)
 
 
-def on_stream_chunk(priority: int = 10, rule: Optional[Rule] = None) -> Hooked:
+def on_stream_chunk(priority: int = 10, rule: Rule | None = None) -> Hooked:
     """
     注册一个钩子函数。
     这个函数将在流式调用中途(`Muice` 的 `model.ask()`)调用
@@ -182,7 +177,7 @@ def on_stream_chunk(priority: int = 10, rule: Optional[Rule] = None) -> Hooked:
     return Hooked(HookType.ON_STREAM_CHUNK, priority=priority, rule=rule)
 
 
-def on_after_completion(priority: int = 10, stream: Optional[bool] = None, rule: Optional[Rule] = None) -> Hooked:
+def on_after_completion(priority: int = 10, stream: bool | None = None, rule: Rule | None = None) -> Hooked:
     """
     注册一个钩子函数。
     这个函数将在传入模型(`Muice` 的 `model.ask()`)后调用（流式则传入整合后的数据）
@@ -197,7 +192,7 @@ def on_after_completion(priority: int = 10, stream: Optional[bool] = None, rule:
     return Hooked(HookType.AFTER_MODEL_COMPLETION, priority=priority, stream=stream, rule=rule)
 
 
-def on_finish_chat(priority: int = 10, rule: Optional[Rule] = None) -> Hooked:
+def on_finish_chat(priority: int = 10, rule: Rule | None = None) -> Hooked:
     """
     注册一个钩子函数。
     这个函数将在结束对话(存库前)调用

--- a/muicebot/plugin/loader.py
+++ b/muicebot/plugin/loader.py
@@ -12,7 +12,6 @@ Functions:
 import inspect
 import os
 from pathlib import Path
-from typing import Dict, Optional, Set
 
 import nonebot_plugin_localstore as store
 from nonebot import load_plugin as load_plugin_as_nonebot
@@ -22,13 +21,13 @@ from nonebot.plugin import PluginMetadata
 from .models import Plugin
 from .utils import path_to_module_name
 
-_plugins: Dict[str, Plugin] = {}
+_plugins: dict[str, Plugin] = {}
 """插件注册表"""
-_declared_plugins: Set[str] = set()
+_declared_plugins: set[str] = set()
 """已声明插件注册表（不一定加载成功）"""
 
 
-def load_plugin(plugin_path: Path | str, base_path=Path.cwd()) -> Optional[Plugin]:
+def load_plugin(plugin_path: Path | str, base_path=Path.cwd()) -> Plugin | None:
     """
     加载单个插件
 
@@ -52,7 +51,7 @@ def load_plugin(plugin_path: Path | str, base_path=Path.cwd()) -> Optional[Plugi
         assert nb_plugin
 
         # get plugin metadata
-        metadata: Optional[PluginMetadata] = nb_plugin.metadata
+        metadata: PluginMetadata | None = nb_plugin.metadata
 
         plugin = Plugin(name=nb_plugin.module_name, module=nb_plugin.module, package_name=module_name, meta=metadata)
 
@@ -93,7 +92,7 @@ def load_plugins(*plugins_dirs: Path | str, base_path=Path.cwd()) -> set[Plugin]
     return plugins
 
 
-def _get_caller_plugin_name() -> Optional[str]:
+def _get_caller_plugin_name() -> str | None:
     """
     获取当前调用插件名
     （默认跳过 `muicebot` 本身及其内嵌插件）
@@ -127,14 +126,14 @@ def _get_caller_plugin_name() -> Optional[str]:
     return None
 
 
-def get_plugins() -> Dict[str, Plugin]:
+def get_plugins() -> dict[str, Plugin]:
     """
     获取插件列表
     """
     return _plugins
 
 
-def get_plugin_by_module_name(module_name: str) -> Optional[Plugin]:
+def get_plugin_by_module_name(module_name: str) -> Plugin | None:
     """
     通过包名获取插件对象
     """

--- a/muicebot/plugin/models.py
+++ b/muicebot/plugin/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Type
 
 from nonebot.plugin import PluginMetadata as NonebotPluginMetadata
 
@@ -19,9 +19,9 @@ class PluginMetadata(NonebotPluginMetadata):
     """插件描述"""
     usage: str
     """插件用法"""
-    homepage: Optional[str] = None
+    homepage: str | None = None
     """(可选) 插件主页，通常为开源存储库地址"""
-    config: Optional[Type["BaseModel"]] = None
+    config: Type["BaseModel"] | None = None
     """插件配置项类，如无需配置可不填写"""
     extra: dict[Any, Any] = field(default_factory=dict)
     """不知道干嘛的 extra 信息，我至今都没搞懂，喜欢的可以填"""
@@ -37,7 +37,7 @@ class Plugin:
     """插件模块对象"""
     package_name: str
     """模块包名"""
-    meta: Optional[Union[PluginMetadata, NonebotPluginMetadata]] = None
+    meta: PluginMetadata | NonebotPluginMetadata | None = None
     """插件元数据"""
 
     def __hash__(self) -> int:

--- a/muicebot/templates/model.py
+++ b/muicebot/templates/model.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -22,7 +20,7 @@ class PromptTemplatesConfig(BaseModel):
     master_nickname: str = "沐沐(Muika)"
     """AI 开发者昵称"""
 
-    userinfos: List[Userinfo] = Field(default=[])
+    userinfos: list[Userinfo] = Field(default=[])
     """用户信息列表"""
 
     model_config = ConfigDict(extra="allow")

--- a/muicebot/utils/SessionManager.py
+++ b/muicebot/utils/SessionManager.py
@@ -1,5 +1,4 @@
 import asyncio
-from typing import Dict, List, Optional
 
 from nonebot import logger
 from nonebot.adapters import Event
@@ -10,7 +9,7 @@ from ..config import plugin_config
 
 class SessionManager:
     def __init__(self) -> None:
-        self.sessions: Dict[str, List[UniMsg]] = {}
+        self.sessions: dict[str, list[UniMsg]] = {}
         self._lock: asyncio.Lock = asyncio.Lock()
         self._timeout = plugin_config.input_timeout
 
@@ -32,7 +31,7 @@ class SessionManager:
 
         return merged_message
 
-    async def put_and_wait(self, event: Event, message: UniMsg) -> Optional[UniMessage]:
+    async def put_and_wait(self, event: Event, message: UniMsg) -> UniMessage | None:
         sid = event.get_session_id()
         await self._put(sid, message)
 

--- a/muicebot/utils/utils.py
+++ b/muicebot/utils/utils.py
@@ -7,7 +7,6 @@ from importlib.metadata import PackageNotFoundError, version
 from io import BytesIO
 from mimetypes import guess_type
 from pathlib import Path
-from typing import Optional
 
 import fleep
 import httpx
@@ -36,7 +35,7 @@ User_Agent = (
 
 
 async def download_file(
-    file_url: str, file_name: Optional[str] = None, proxy: Optional[str] = None, cache: bool = False
+    file_url: str, file_name: str | None = None, proxy: str | None = None, cache: bool = False
 ) -> str:
     """
     保存文件至本地目录(在未提供后缀的情况下, 默认为.jpg后缀)
@@ -62,7 +61,7 @@ async def download_file(
         return str(local_path)
 
 
-async def save_image_as_base64(image_url: str, proxy: Optional[str] = None) -> str:
+async def save_image_as_base64(image_url: str, proxy: str | None = None) -> str:
     """
     从在线 url 获取图像 Base64
 
@@ -78,7 +77,7 @@ async def save_image_as_base64(image_url: str, proxy: Optional[str] = None) -> s
     return image_base64.decode("utf-8")
 
 
-async def get_file_via_adapter(message: MessageSegment, event: Event) -> Optional[str]:
+async def get_file_via_adapter(message: MessageSegment, event: Event) -> str | None:
     """
     通过适配器自有方式获取文件地址并保存到本地
 
@@ -193,7 +192,7 @@ def get_version() -> str:
         return "Unknown"
 
 
-async def get_username(user_id: Optional[str] = None, event: Optional[Event] = None) -> str:
+async def get_username(user_id: str | None = None, event: Event | None = None) -> str:
     """
     获取当前对话的用户名，如果失败就返回用户id
 
@@ -208,7 +207,7 @@ async def get_username(user_id: Optional[str] = None, event: Optional[Event] = N
     return user_info.user_name if user_info else user_id
 
 
-def guess_mimetype(resource: Resource) -> Optional[str]:
+def guess_mimetype(resource: Resource) -> str | None:
     """
     尝试获取 minetype 类型
     """


### PR DESCRIPTION
这个commit将代码中的类型注解从`Optional[T]`和`Union[A, B]`等旧式注解更新为Python 3.10+的新式语法`T | None`和`A | B`。主要变更包括：

1. 移除了不必要的`typing`导入如`Optional`, `Union`, `List`, `Dict`等
2. 将所有`Optional[T]`替换为`T | None`
3. 将所有`Union[A, B]`替换为`A | B`
4. 将所有`List[T]`替换为`list[T]`
5. 将所有`Dict[K, V]`替换为`dict[K, V]`

这些变更使代码更简洁，同时保持完全相同的类型检查功能。

~~（这是一个完全 vibe coding 的结果，当然我也让 [gemini-code-assist](https://github.com/apps/gemini-code-assist) 审核过，没有任何意见）~~